### PR TITLE
Auto-negotiate 10-bit color format output when decoding HEVC Main 10 streams

### DIFF
--- a/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
+++ b/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
@@ -332,9 +332,7 @@ gst_mfx_window_d3d11_init_swap_chain (GstMfxWindowD3D11 * window)
   );
 
   /* if chosen format isn't a possible render target */
-  if (swap_chain_desc.Format == DXGI_FORMAT_P010)
-    swap_chain_desc.Format = DXGI_FORMAT_R10G10B10A2_UNORM;
-  else
+  if (swap_chain_desc.Format != DXGI_FORMAT_R10G10B10A2_UNORM)
     swap_chain_desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
 
   swap_chain_desc.SampleDesc.Count = 1;

--- a/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
+++ b/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
@@ -332,7 +332,8 @@ gst_mfx_window_d3d11_init_swap_chain (GstMfxWindowD3D11 * window)
   );
 
   /* if chosen format isn't a possible render target */
-  if (swap_chain_desc.Format != DXGI_FORMAT_R10G10B10A2_UNORM)
+  if (swap_chain_desc.Format != DXGI_FORMAT_R10G10B10A2_UNORM
+      && swap_chain_desc.Format != DXGI_FORMAT_P010)
     swap_chain_desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
 
   swap_chain_desc.SampleDesc.Count = 1;

--- a/gst-libs/mfx/gstmfxdecoder.c
+++ b/gst-libs/mfx/gstmfxdecoder.c
@@ -74,11 +74,17 @@ struct _GstMfxDecoder
 
 G_DEFINE_TYPE(GstMfxDecoder, gst_mfx_decoder, GST_TYPE_OBJECT);
 
+void
+gst_mfx_decoder_set_video_info (GstMfxDecoder * decoder, GstVideoInfo * info)
+{
+  g_return_val_if_fail (decoder != NULL, NULL);
+  decoder->info = *info;
+}
+
 const GstMfxProfile *
 gst_mfx_decoder_get_profile (GstMfxDecoder * decoder)
 {
   g_return_val_if_fail (decoder != NULL, NULL);
-
   return &decoder->profile;
 }
 

--- a/gst-libs/mfx/gstmfxdecoder.c
+++ b/gst-libs/mfx/gstmfxdecoder.c
@@ -74,7 +74,7 @@ struct _GstMfxDecoder
 
 G_DEFINE_TYPE(GstMfxDecoder, gst_mfx_decoder, GST_TYPE_OBJECT);
 
-GstMfxProfile *
+const GstMfxProfile *
 gst_mfx_decoder_get_profile (GstMfxDecoder * decoder)
 {
   g_return_val_if_fail (decoder != NULL, NULL);

--- a/gst-libs/mfx/gstmfxdecoder.h
+++ b/gst-libs/mfx/gstmfxdecoder.h
@@ -89,7 +89,7 @@ void
 gst_mfx_decoder_replace (GstMfxDecoder ** old_decoder_ptr,
     GstMfxDecoder * new_decoder);
 
-GstMfxProfile *
+const GstMfxProfile *
 gst_mfx_decoder_get_profile (GstMfxDecoder * decoder);
 
 gboolean

--- a/gst-libs/mfx/gstmfxdecoder.h
+++ b/gst-libs/mfx/gstmfxdecoder.h
@@ -99,8 +99,8 @@ gst_mfx_decoder_get_decoded_frames (GstMfxDecoder * decoder,
 GstVideoCodecFrame *
 gst_mfx_decoder_get_discarded_frame (GstMfxDecoder * decoder);
 
-GstVideoInfo *
-gst_mfx_decoder_get_video_info (GstMfxDecoder * decoder);
+void
+gst_mfx_decoder_set_video_info (GstMfxDecoder * decoder, GstVideoInfo * info);
 
 void
 gst_mfx_decoder_skip_corrupted_frames (GstMfxDecoder * decoder);

--- a/gst-libs/mfx/gstmfxdisplay.c
+++ b/gst-libs/mfx/gstmfxdisplay.c
@@ -103,7 +103,7 @@ end:
 
 /* GstMfxDisplayType enumerations */
 GType
-gst_mfx_display_get_type (void)
+gst_mfx_display_type_get_type (void)
 {
   static GType g_type = 0;
 

--- a/gst-libs/mfx/gstmfxencoder.c
+++ b/gst-libs/mfx/gstmfxencoder.c
@@ -1231,6 +1231,10 @@ gst_mfx_encoder_encode (GstMfxEncoder * encoder, GstVideoCodecFrame * frame)
   if (syncp) {
     do {
       sts = MFXVideoCORE_SyncOperation (priv->session, syncp, 1000);
+      if (MFX_ERR_NONE != sts && sts < 0) {
+        GST_ERROR("MFXVideoCORE_SyncOperation() error status: %d", sts);
+        return GST_MFX_ENCODER_STATUS_ERROR_OPERATION_FAILED;
+      }
     } while (MFX_WRN_IN_EXECUTION == sts);
 
     frame->output_buffer =

--- a/gst-libs/mfx/gstmfxfilter.c
+++ b/gst-libs/mfx/gstmfxfilter.c
@@ -128,8 +128,8 @@ gst_mfx_filter_set_frame_info_from_gst_video_info (GstMfxFilter * filter,
   filter->frame_info.FrameRateExtD = info->fps_d;
   filter->frame_info.AspectRatioW = info->par_n;
   filter->frame_info.AspectRatioH = info->par_d;
-  filter->frame_info.BitDepthChroma = 8;
-  filter->frame_info.BitDepthLuma = 8;
+  filter->frame_info.BitDepthChroma = filter->frame_info.BitDepthLuma =
+    (MFX_FOURCC_P010 == filter->frame_info.FourCC) ? 10 : 8;
 
   filter->frame_info.Width = GST_ROUND_UP_16 (info->width);
   filter->frame_info.Height =

--- a/gst-libs/mfx/gstmfxfilter.c
+++ b/gst-libs/mfx/gstmfxfilter.c
@@ -1079,7 +1079,7 @@ gst_mfx_filter_process (GstMfxFilter * filter, GstMfxSurface * surface,
   }
 
   if (MFX_ERR_NONE != sts) {
-    GST_ERROR ("Error during MFX filter process.");
+    GST_ERROR ("MFXVideoVPP_RunFrameVPPAsync() error status: %d", sts);
     return GST_MFX_FILTER_STATUS_ERROR_OPERATION_FAILED;
   }
 
@@ -1087,6 +1087,10 @@ gst_mfx_filter_process (GstMfxFilter * filter, GstMfxSurface * surface,
     if (!gst_mfx_task_has_type (filter->vpp[1], GST_MFX_TASK_ENCODER))
       do {
         sts = MFXVideoCORE_SyncOperation (filter->session, syncp, 1000);
+        if (MFX_ERR_NONE != sts && sts < 0) {
+          GST_ERROR("MFXVideoCORE_SyncOperation() error status: %d", sts);
+          return GST_MFX_FILTER_STATUS_ERROR_OPERATION_FAILED;
+        }
       } while (MFX_WRN_IN_EXECUTION == sts);
 
     *out_surface =

--- a/gst-libs/mfx/gstmfxsurface.c
+++ b/gst-libs/mfx/gstmfxsurface.c
@@ -106,6 +106,7 @@ gst_mfx_surface_allocate_default (GstMfxSurface * surface, GstMfxTask * task)
 
     break;
   case MFX_FOURCC_RGB4:
+  case MFX_FOURCC_A2RGB10:
     priv->data_size = frame_size * 4;
     priv->data = g_slice_alloc(priv->data_size);
     if (!priv->data)

--- a/gst-libs/mfx/gstmfxsurface_vaapi.c
+++ b/gst-libs/mfx/gstmfxsurface_vaapi.c
@@ -47,8 +47,8 @@ gst_mfx_surface_vaapi_from_task(GstMfxSurface * surface,
   if (!mid)
     return FALSE;
 
-  surface->surface.Data.MemId = mid;
-  surface->surface_id = (GstMfxID) (*((VASurfaceID *) mid->mid));
+  priv->surface.Data.MemId = mid;
+  priv->surface_id = (GstMfxID) (*((VASurfaceID *) mid->mid));
   return TRUE;
 }
 

--- a/gst-libs/mfx/gstmfxtask.c
+++ b/gst-libs/mfx/gstmfxtask.c
@@ -213,18 +213,21 @@ gst_mfx_task_create (GstMfxTask * task, GstMfxTaskAggregator * aggregator,
   priv->aggregator = gst_mfx_task_aggregator_ref (aggregator);
   priv->context = gst_mfx_task_aggregator_get_context(aggregator);
   priv->memtype_is_system = FALSE;
+  mfxHandleType handle_type;
+
 #ifdef WITH_LIBVA_BACKEND
-  mfxHandleType handle_type = MFX_HANDLE_VA_DISPLAY;
+  handle_type = MFX_HANDLE_VA_DISPLAY;
   device_handle =
       GST_MFX_DISPLAY_VADISPLAY(gst_mfx_context_get_device(priv->context));
 #else
+  handle_type = MFX_HANDLE_D3D11_DEVICE;
   device_handle = (ID3D11Device*)
       gst_mfx_d3d11_device_get_handle (gst_mfx_context_get_device(priv->context));
 #endif
 
-  sts = MFXVideoCORE_GetHandle(priv->session, MFX_HANDLE_D3D11_DEVICE, &device_handle);
+  sts = MFXVideoCORE_GetHandle(priv->session, handle_type, &device_handle);
   if (MFX_ERR_NONE != sts) {
-    sts = MFXVideoCORE_SetHandle(priv->session, MFX_HANDLE_D3D11_DEVICE, device_handle);
+    sts = MFXVideoCORE_SetHandle(priv->session, handle_type, device_handle);
     if (MFX_ERR_NONE != sts)
       return FALSE;
   }

--- a/gst/mfx/gstmfxdec.c
+++ b/gst/mfx/gstmfxdec.c
@@ -213,6 +213,8 @@ gst_mfxdec_update_src_caps (GstMfxDec * mfxdec)
   gst_caps_replace (&mfxdec->srcpad_caps, state->caps);
   gst_video_codec_state_unref (state);
 
+  gst_mfx_decoder_set_video_info (mfxdec->decoder, vi);
+
   return TRUE;
 }
 

--- a/gst/mfx/gstmfxdec.c
+++ b/gst/mfx/gstmfxdec.c
@@ -175,6 +175,7 @@ gst_mfxdec_update_src_caps (GstMfxDec * mfxdec)
   GstCapsFeatures *features = NULL;
   GstMfxCapsFeature feature;
   const GstMfxProfile *profile;
+  gboolean use_10bpc = FALSE;
 
   if (!mfxdec->input_state)
     return FALSE;
@@ -182,15 +183,13 @@ gst_mfxdec_update_src_caps (GstMfxDec * mfxdec)
   profile = gst_mfx_decoder_get_profile (mfxdec->decoder);
   if (profile->codec == MFX_CODEC_HEVC
       && profile->profile == MFX_PROFILE_HEVC_MAIN10)
-    native_format = GST_VIDEO_FORMAT_P010_10LE;
-  else
-    native_format = GST_VIDEO_FORMAT_UNKNOWN;
+    use_10bpc = TRUE;
 
   ref_state = mfxdec->input_state;
 
   feature =
       gst_mfx_find_preferred_caps_feature (GST_VIDEO_DECODER_SRC_PAD (vdec),
-        native_format, &output_format);
+        use_10bpc, &output_format);
 
   if (GST_MFX_CAPS_FEATURE_NOT_NEGOTIATED == feature)
     return FALSE;

--- a/gst/mfx/gstmfxpluginutil.c
+++ b/gst/mfx/gstmfxpluginutil.c
@@ -172,7 +172,7 @@ gst_mfx_video_format_new_template_caps_with_features (GstVideoFormat format,
 
 GstMfxCapsFeature
 gst_mfx_find_preferred_caps_feature (GstPad * pad,
-    GstVideoFormat * out_format_ptr)
+  GstVideoFormat in_format, GstVideoFormat * out_format_ptr)
 {
   GstMfxCapsFeature feature = GST_MFX_CAPS_FEATURE_SYSTEM_MEMORY;
   guint num_structures;
@@ -182,7 +182,13 @@ gst_mfx_find_preferred_caps_feature (GstPad * pad,
   const gchar *format = NULL;
 
   templ = gst_pad_get_pad_template_caps (pad);
+
   in_caps = gst_pad_peer_query_caps (pad, templ);
+
+  /* Change to preferred format */
+  if (in_format != GST_VIDEO_FORMAT_UNKNOWN)
+    gst_caps_set_simple(in_caps, "format", G_TYPE_STRING,
+      gst_video_format_to_string(in_format), NULL);
 
   out_caps = gst_caps_intersect_full (in_caps,
       templ, GST_CAPS_INTERSECT_FIRST);

--- a/gst/mfx/gstmfxpluginutil.h
+++ b/gst/mfx/gstmfxpluginutil.h
@@ -61,7 +61,7 @@ gst_mfx_video_format_new_template_caps_with_features(GstVideoFormat format,
 
 GstMfxCapsFeature
 gst_mfx_find_preferred_caps_feature(GstPad * pad,
-    GstVideoFormat * out_format_ptr);
+  GstVideoFormat in_format, GstVideoFormat * out_format_ptr);
 
 const gchar *
 gst_mfx_caps_feature_to_string(GstMfxCapsFeature feature);

--- a/gst/mfx/gstmfxpluginutil.h
+++ b/gst/mfx/gstmfxpluginutil.h
@@ -53,15 +53,12 @@ GstCaps *
 gst_mfx_video_format_new_template_caps(GstVideoFormat format);
 
 GstCaps *
-gst_mfx_video_format_new_template_caps_from_list(GArray * formats);
-
-GstCaps *
 gst_mfx_video_format_new_template_caps_with_features(GstVideoFormat format,
   const gchar * features_string);
 
 GstMfxCapsFeature
 gst_mfx_find_preferred_caps_feature(GstPad * pad,
-  GstVideoFormat in_format, GstVideoFormat * out_format_ptr);
+  gboolean use_10bpc, GstVideoFormat * out_format_ptr);
 
 const gchar *
 gst_mfx_caps_feature_to_string(GstMfxCapsFeature feature);

--- a/gst/mfx/gstmfxpostproc.c
+++ b/gst/mfx/gstmfxpostproc.c
@@ -891,7 +891,7 @@ gst_mfxpostproc_transform_caps_impl (GstBaseTransform * trans,
 
   feature =
       gst_mfx_find_preferred_caps_feature (GST_BASE_TRANSFORM_SRC_PAD (trans),
-        DEFAULT_FORMAT, &out_format);
+        GST_VIDEO_FORMAT_UNKNOWN, &out_format);
   gst_video_info_change_format (&vi, out_format, width, height);
 
   out_caps = gst_video_info_to_caps (&vi);

--- a/gst/mfx/gstmfxpostproc.c
+++ b/gst/mfx/gstmfxpostproc.c
@@ -891,7 +891,7 @@ gst_mfxpostproc_transform_caps_impl (GstBaseTransform * trans,
 
   feature =
       gst_mfx_find_preferred_caps_feature (GST_BASE_TRANSFORM_SRC_PAD (trans),
-        &out_format);
+        DEFAULT_FORMAT, &out_format);
   gst_video_info_change_format (&vi, out_format, width, height);
 
   out_caps = gst_video_info_to_caps (&vi);

--- a/gst/mfx/gstmfxpostproc.c
+++ b/gst/mfx/gstmfxpostproc.c
@@ -881,7 +881,7 @@ gst_mfxpostproc_transform_caps_impl (GstBaseTransform * trans,
 
   feature =
       gst_mfx_find_preferred_caps_feature (GST_BASE_TRANSFORM_SRC_PAD (trans),
-        FALSE, &out_format);
+        GST_VIDEO_INFO_FORMAT(&vi) == GST_VIDEO_FORMAT_P010_10LE, &out_format);
   gst_video_info_change_format (&vi, out_format, width, height);
 
   out_caps = gst_video_info_to_caps (&vi);

--- a/gst/mfx/gstmfxsink.c
+++ b/gst/mfx/gstmfxsink.c
@@ -47,7 +47,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_debug_mfxsink);
 /* Default template */
 static const char gst_mfxsink_sink_caps_str[] = 
 GST_VIDEO_CAPS_MAKE_WITH_FEATURES(
-  GST_CAPS_FEATURE_MEMORY_MFX_SURFACE, "{ BGRA, ENCODED, P010_10LE, NV12 }"
+  GST_CAPS_FEATURE_MEMORY_MFX_SURFACE, "{ NV12, BGRA, ENCODED }"
 ) ";";
 
 static GstStaticPadTemplate gst_mfxsink_sink_factory =

--- a/gst/mfx/gstmfxsink.c
+++ b/gst/mfx/gstmfxsink.c
@@ -47,7 +47,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_debug_mfxsink);
 /* Default template */
 static const char gst_mfxsink_sink_caps_str[] = 
 GST_VIDEO_CAPS_MAKE_WITH_FEATURES(
-  GST_CAPS_FEATURE_MEMORY_MFX_SURFACE, "{ NV12, BGRA, ENCODED }"
+  GST_CAPS_FEATURE_MEMORY_MFX_SURFACE, "{ NV12, BGRA, P010_10LE, ENCODED }"
 ) ";";
 
 static GstStaticPadTemplate gst_mfxsink_sink_factory =


### PR DESCRIPTION
When decoding HEVC Main 10 streams, it is preferable to keep the color fidelity to 10 bits if the hardware can support it. The patches enable auto-negotiation of native P010 format from such streams to downstream elements as the preferred format, thereby avoiding an unnecessary color space conversion and color accuracy loss.